### PR TITLE
Fix invalid line in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,11 +3,7 @@ version=0.1
 author=Greg Bumgardner <gbumgard@gmail.com>
 maintainer=Greg Bumgardner <gbumgard@gmail.com>
 sentence=Class wrapper that adds half-duplex support to Arduino HardwareSerial objects.
-paragraph=Construct an instance of this class to add half-duplex support to the predefined hardware serial objects.
-The hardware serial object to be wrapped is specified as a constructor argument.
-Use the member functions on this wrapper to access the underlying Serial(n) instance.
-Duplex control is provided by the setDirection() member function.
-Restricting operation to the half-duplex modes allows the Rx and Tx pins to be tied to a one-wire serial bus.
+paragraph=Construct an instance of this class to add half-duplex support to the predefined hardware serial objects. The hardware serial object to be wrapped is specified as a constructor argument. Use the member functions on this wrapper to access the underlying Serial(n) instance. Duplex control is provided by the setDirection() member function. Restricting operation to the half-duplex modes allows the Rx and Tx pins to be tied to a one-wire serial bus.
 category=Communication
 url=https://github.com/gbumgard/HalfDuplexHardwareSerial
 architectures=avr


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't #include the library) to fail:

Property line '...' in file ... is invalid

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format